### PR TITLE
feat: Add YAML configuration support

### DIFF
--- a/etsi/watchdog/config/__init__.py
+++ b/etsi/watchdog/config/__init__.py
@@ -1,0 +1,14 @@
+# etsi/watchdog/config/__init__.py
+"""YAML Configuration module for etsi-watchdog."""
+
+from .parser import ConfigParser
+from .runner import ConfigRunner
+from .schema import DriftConfig
+
+__all__ = ['ConfigParser', 'ConfigRunner', 'DriftConfig']
+
+
+def run_from_yaml(config_path: str):
+    """Quick function to run drift detection from YAML."""
+    runner = ConfigRunner()
+    return runner.run_from_config(config_path)

--- a/etsi/watchdog/config/parser.py
+++ b/etsi/watchdog/config/parser.py
@@ -1,0 +1,40 @@
+# etsi/watchdog/config/parser.py
+import yaml
+from typing import Dict, Any
+from pathlib import Path
+from .schema import DriftConfig, AlgorithmConfig, OutputConfig, MonitoringConfig
+
+class ConfigParser:
+    def load_config(self, config_path: str) -> DriftConfig:
+        """Load YAML config and convert to DriftConfig object."""
+     
+        with open(config_path, 'r') as file:
+            config_data = yaml.safe_load(file)
+        
+       
+        drift_section = config_data['drift_detection']
+        
+      
+        algorithms = []
+        for algo_dict in drift_section['algorithms']:
+            algorithms.append(AlgorithmConfig(**algo_dict))
+        
+        
+        output_config = OutputConfig(**drift_section['output'])
+        
+       
+        monitoring_config = None
+        if 'monitoring' in drift_section:
+            monitoring_config = MonitoringConfig(**drift_section['monitoring'])
+        
+        
+        config = DriftConfig(
+            reference_data=drift_section['reference_data'],
+            current_data=drift_section['current_data'],
+            features=drift_section['features'],
+            algorithms=algorithms,
+            output=output_config,
+            monitoring=monitoring_config
+        )
+        
+        return config

--- a/etsi/watchdog/config/runner.py
+++ b/etsi/watchdog/config/runner.py
@@ -1,0 +1,60 @@
+# etsi/watchdog/config/runner.py
+import pandas as pd
+import json
+from pathlib import Path
+from .parser import ConfigParser
+from .schema import DriftConfig
+from ..drift_check import DriftCheck  # Import your existing class
+
+class ConfigRunner:
+    def __init__(self):
+        self.parser = ConfigParser()
+    
+    def run_from_config(self, config_path: str):
+        """Run drift detection from YAML config."""
+        config = self.parser.load_config(config_path)
+        ref_data = pd.read_csv(config.reference_data)
+        current_data = pd.read_csv(config.current_data)
+        print(f"Loaded reference data: {len(ref_data)} rows")
+        print(f"Loaded current data: {len(current_data)} rows")
+        
+        check = DriftCheck(ref_data)
+        results = check.run(current_data, features=config.features)
+        
+        self._save_results(results, config.output)
+        
+        return results
+    
+    def _save_results(self, results, output_config):
+        """Save results based on output configuration."""
+        output_path = Path(output_config.path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        if output_config.format == "json":
+           
+            json_results = self._results_to_dict(results)
+            with open(output_path, 'w') as f:
+                json.dump(json_results, f, indent=2, default=str)
+        
+        print(f"Results saved to: {output_path}")
+        
+  
+        if output_config.visualizations:
+            print("Generating visualizations...")
+    
+            for feature, result in results.items():
+                if hasattr(result, 'plot'):
+                    result.plot()
+    
+    def _results_to_dict(self, results):
+        """Convert your DriftCheck results to dictionary."""
+     
+        json_results = {}
+        for feature, result in results.items():
+            json_results[feature] = {
+                'drift_detected': getattr(result, 'drift_detected', False),
+                'psi_value': getattr(result, 'psi_value', None),
+                'threshold': getattr(result, 'threshold', None),
+               
+            }
+        return json_results

--- a/etsi/watchdog/config/schema.py
+++ b/etsi/watchdog/config/schema.py
@@ -1,0 +1,30 @@
+
+from typing import Dict, List, Optional, Union, Any
+from dataclasses import dataclass
+
+@dataclass
+class AlgorithmConfig:
+    name: str
+    threshold: float
+    params: Optional[Dict[str, Any]] = None
+
+@dataclass
+class OutputConfig:
+    format: str 
+    path: str
+    visualizations: bool = True
+
+@dataclass
+class MonitoringConfig:
+    window_size: int
+    frequency: str 
+    log_path: str
+
+@dataclass
+class DriftConfig:
+    reference_data: str
+    current_data: str
+    features: List[str]
+    algorithms: List[AlgorithmConfig]
+    output: OutputConfig
+    monitoring: Optional[MonitoringConfig] = None


### PR DESCRIPTION
# feat: Implement YAML Configuration and Command-Line Interface

## Summary

This PR introduces a robust, YAML-based configuration system and a full-featured Command-Line Interface (CLI) to decouple the drift detection setup from the execution logic.

This allows users to run complex drift checks without writing Python boilerplate, using either a configuration file or direct terminal commands. This significantly improves usability and enables seamless integration into automated MLOps pipelines.

## Key Changes

- **New config Module**: Introduced a self-contained module (`etsi/watchdog/config`) containing all configuration-related logic.
- **Dataclass-based Schema**: Defined a strict configuration structure using Python dataclasses (`schema.py`) for type safety and clarity.
- **Parser & Runner**: Implemented a `parser.py` to load YAML into dataclass objects and a `runner.py` to execute the drift detection workflow from the parsed configuration.
- **Command-Line Interface (CLI)**: Added a new `cli.py` module using `click`, providing `from-config` and `detect` commands for easy execution directly from the terminal.
- **Refactored DriftCheck**: The core `DriftCheck` class was refactored to be a flexible runner capable of handling a list of different algorithms passed to it at runtime.
- **End-to-End Testing**: Added a new test function (`test_config_runner`) that verifies the entire YAML workflow. Existing bugs in the test suite were also fixed.

## How to Test

### 1. Test with a YAML Configuration File

Create a `config.yaml` file and a `data/` directory with sample CSVs in the project root as discussed.

Run the following command from the terminal:

```bash
etsi-watchdog from-config --config config.yaml
```

### 2. Test with Direct CLI Arguments

Using the same `data/` directory, run the detect command directly:

```bash
etsi-watchdog detect --ref data/reference.csv --current data/live.csv --features "age,salary"
```

## Example Output

Running the `from-config` command produces the following output, correctly issuing a warning for the small sample size and generating the report:

**Terminal Output:**
```
Loading configuration from: config.yaml
Loading data...
Loaded reference data: 5 rows
Loaded current data: 5 rows
Running drift check on features: ['age', 'salary']
... UserWarning: [etsi-watchdog] Sample size too small for reliable PSI (<50): 5
Results saved to: config_drift_report.json
Drift check complete.
✅ Done.
```

Generated `config_drift_report.json`:

```json
{
  "age": {
    "psi": {
      "drift_detected": false,
      "value": null,
      "threshold": 0.2
    }
  },
  "salary": {
    "psi": {
      "drift_detected": false,
      "value": null,
      "threshold": 0.2
    }
  }
}
```

---

Closes #4, Closes #26