### PR TITLE
feat(cli): Add command-line interface

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,15 @@
+drift_detection:
+  reference_data: "data/reference.csv"
+  current_data: "data/live.csv"
+  features:
+    - "age"
+    - "salary"
+  
+  algorithms:
+    - name: "psi"
+      threshold: 0.2
+  
+  output:
+    format: "json"
+    path: "config_drift_report.json"
+    visualizations: false

--- a/etsi/watchdog/__init__.py
+++ b/etsi/watchdog/__init__.py
@@ -9,8 +9,8 @@ Exposes:
 - DriftComparator: compare two drift runs
 - DriftResult: result object with summary, plot, and JSON support
 - SlackNotifier: Slack alert notifications for drift detection
-- WatchdogConfig: Configuration helper for easy setup
-- quick_setup: Convenience function for quick configuration
+- DriftConfig: Configuration helper for easy setup
+- run_from_yaml: Convenience function for quick configuration
 """
 
 from .drift_check import DriftCheck
@@ -18,7 +18,7 @@ from .monitor import Monitor
 from .compare import DriftComparator
 from .drift.base import DriftResult
 from .slack_notifier import SlackNotifier
-from .config import WatchdogConfig, quick_setup
+from .config import DriftConfig, run_from_yaml
 
 __all__ = [
     "DriftCheck",
@@ -26,6 +26,6 @@ __all__ = [
     "DriftComparator",
     "DriftResult",
     "SlackNotifier",
-    "WatchdogConfig",
-    "quick_setup",
+    "DriftConfig",
+    "run_from_yaml",
 ]

--- a/etsi/watchdog/config/__init__.py
+++ b/etsi/watchdog/config/__init__.py
@@ -1,0 +1,14 @@
+# etsi/watchdog/config/__init__.py
+"""YAML Configuration module for etsi-watchdog."""
+
+from .parser import ConfigParser
+from .runner import ConfigRunner
+from .schema import DriftConfig
+
+__all__ = ['ConfigParser', 'ConfigRunner', 'DriftConfig']
+
+
+def run_from_yaml(config_path: str):
+    """Quick function to run drift detection from YAML."""
+    runner = ConfigRunner()
+    return runner.run_from_config(config_path)

--- a/etsi/watchdog/config/parser.py
+++ b/etsi/watchdog/config/parser.py
@@ -1,0 +1,40 @@
+# etsi/watchdog/config/parser.py
+import yaml
+from typing import Dict, Any
+from pathlib import Path
+from .schema import DriftConfig, AlgorithmConfig, OutputConfig, MonitoringConfig
+
+class ConfigParser:
+    def load_config(self, config_path: str) -> DriftConfig:
+        """Load YAML config and convert to DriftConfig object."""
+     
+        with open(config_path, 'r') as file:
+            config_data = yaml.safe_load(file)
+        
+       
+        drift_section = config_data['drift_detection']
+        
+      
+        algorithms = []
+        for algo_dict in drift_section['algorithms']:
+            algorithms.append(AlgorithmConfig(**algo_dict))
+        
+        
+        output_config = OutputConfig(**drift_section['output'])
+        
+       
+        monitoring_config = None
+        if 'monitoring' in drift_section:
+            monitoring_config = MonitoringConfig(**drift_section['monitoring'])
+        
+        
+        config = DriftConfig(
+            reference_data=drift_section['reference_data'],
+            current_data=drift_section['current_data'],
+            features=drift_section['features'],
+            algorithms=algorithms,
+            output=output_config,
+            monitoring=monitoring_config
+        )
+        
+        return config

--- a/etsi/watchdog/config/runner.py
+++ b/etsi/watchdog/config/runner.py
@@ -2,59 +2,68 @@
 import pandas as pd
 import json
 from pathlib import Path
-from .parser import ConfigParser
-from .schema import DriftConfig
-from ..drift_check import DriftCheck  # Import your existing class
+from .schema import DriftConfig, OutputConfig
+
 
 class ConfigRunner:
-    def __init__(self):
-        self.parser = ConfigParser()
-    
-    def run_from_config(self, config_path: str):
-        """Run drift detection from YAML config."""
-        config = self.parser.load_config(config_path)
+    """Runs a drift check based on a DriftConfig object."""
+
+    def run(self, config: DriftConfig):
+        """
+        Executes the drift detection workflow from a DriftConfig object.
+        """
+        print("Loading data...")
         ref_data = pd.read_csv(config.reference_data)
         current_data = pd.read_csv(config.current_data)
         print(f"Loaded reference data: {len(ref_data)} rows")
         print(f"Loaded current data: {len(current_data)} rows")
-        
+        from ..drift_check import DriftCheck
+
         check = DriftCheck(ref_data)
-        results = check.run(current_data, features=config.features)
-        
+
+        print(f"Running drift check on features: {config.features}")
+        results = check.run(
+            current_data, 
+            features=config.features,
+            algorithms=config.algorithms 
+        )
+
         self._save_results(results, config.output)
         
+        if config.output.visualizations:
+             print("Generating visualizations...")
+             for feature, result_group in results.items():
+                 for algo_name, result in result_group.items():
+                    if hasattr(result, 'plot'):
+                        print(f"  Plotting {algo_name} for {feature}...")
+                        result.plot()
+
+        print("Drift check complete.")
         return results
-    
-    def _save_results(self, results, output_config):
+
+    def _save_results(self, results, output_config: OutputConfig):
         """Save results based on output configuration."""
         output_path = Path(output_config.path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        
+
         if output_config.format == "json":
-           
+            # This helper function needs to be able to handle the nested results
             json_results = self._results_to_dict(results)
-            with open(output_path, 'w') as f:
-                json.dump(json_results, f, indent=2, default=str)
-        
-        print(f"Results saved to: {output_path}")
-        
-  
-        if output_config.visualizations:
-            print("Generating visualizations...")
-    
-            for feature, result in results.items():
-                if hasattr(result, 'plot'):
-                    result.plot()
-    
+            with open(output_path, "w") as f:
+                json.dump(json_results, f, indent=2)
+            print(f"Results saved to: {output_path}")
+
     def _results_to_dict(self, results):
-        """Convert your DriftCheck results to dictionary."""
-     
-        json_results = {}
-        for feature, result in results.items():
-            json_results[feature] = {
-                'drift_detected': getattr(result, 'drift_detected', False),
-                'psi_value': getattr(result, 'psi_value', None),
-                'threshold': getattr(result, 'threshold', None),
-               
-            }
-        return json_results
+        """
+        Convert your potentially nested DriftCheck results to a serializable dictionary.
+        """
+        serializable_results = {}
+        for feature, result_group in results.items():
+            serializable_results[feature] = {}
+            for algo_name, result in result_group.items():
+                 serializable_results[feature][algo_name] = {
+                    'drift_detected': getattr(result, 'drift_detected', False),
+                    'value': getattr(result, 'value', None), # e.g., PSI or K-S statistic
+                    'threshold': getattr(result, 'threshold', None),
+                 }
+        return serializable_results

--- a/etsi/watchdog/config/runner.py
+++ b/etsi/watchdog/config/runner.py
@@ -1,0 +1,60 @@
+# etsi/watchdog/config/runner.py
+import pandas as pd
+import json
+from pathlib import Path
+from .parser import ConfigParser
+from .schema import DriftConfig
+from ..drift_check import DriftCheck  # Import your existing class
+
+class ConfigRunner:
+    def __init__(self):
+        self.parser = ConfigParser()
+    
+    def run_from_config(self, config_path: str):
+        """Run drift detection from YAML config."""
+        config = self.parser.load_config(config_path)
+        ref_data = pd.read_csv(config.reference_data)
+        current_data = pd.read_csv(config.current_data)
+        print(f"Loaded reference data: {len(ref_data)} rows")
+        print(f"Loaded current data: {len(current_data)} rows")
+        
+        check = DriftCheck(ref_data)
+        results = check.run(current_data, features=config.features)
+        
+        self._save_results(results, config.output)
+        
+        return results
+    
+    def _save_results(self, results, output_config):
+        """Save results based on output configuration."""
+        output_path = Path(output_config.path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        if output_config.format == "json":
+           
+            json_results = self._results_to_dict(results)
+            with open(output_path, 'w') as f:
+                json.dump(json_results, f, indent=2, default=str)
+        
+        print(f"Results saved to: {output_path}")
+        
+  
+        if output_config.visualizations:
+            print("Generating visualizations...")
+    
+            for feature, result in results.items():
+                if hasattr(result, 'plot'):
+                    result.plot()
+    
+    def _results_to_dict(self, results):
+        """Convert your DriftCheck results to dictionary."""
+     
+        json_results = {}
+        for feature, result in results.items():
+            json_results[feature] = {
+                'drift_detected': getattr(result, 'drift_detected', False),
+                'psi_value': getattr(result, 'psi_value', None),
+                'threshold': getattr(result, 'threshold', None),
+               
+            }
+        return json_results

--- a/etsi/watchdog/config/schema.py
+++ b/etsi/watchdog/config/schema.py
@@ -1,0 +1,30 @@
+
+from typing import Dict, List, Optional, Union, Any
+from dataclasses import dataclass
+
+@dataclass
+class AlgorithmConfig:
+    name: str
+    threshold: float
+    params: Optional[Dict[str, Any]] = None
+
+@dataclass
+class OutputConfig:
+    format: str 
+    path: str
+    visualizations: bool = True
+
+@dataclass
+class MonitoringConfig:
+    window_size: int
+    frequency: str 
+    log_path: str
+
+@dataclass
+class DriftConfig:
+    reference_data: str
+    current_data: str
+    features: List[str]
+    algorithms: List[AlgorithmConfig]
+    output: OutputConfig
+    monitoring: Optional[MonitoringConfig] = None

--- a/etsi/watchdog/drift_check.py
+++ b/etsi/watchdog/drift_check.py
@@ -1,41 +1,55 @@
 # etsi/watchdog/drift_check.py
-
+from typing import List, Dict
+import pandas as pd
 from .drift.factory import get_drift_function
-from .drift.base import DriftResult
-
+from .config.schema import AlgorithmConfig
 
 class DriftCheck:
     """
     DriftCheck — Core API to detect drift between reference and current datasets.
-
-    Example:
-    >>> check = DriftCheck(reference_df)
-    >>> results = check.run(current_df, features=["age", "salary"])
+    This class can run multiple drift detection algorithms in a single pass.
     """
 
-    def __init__(self, reference_df, algorithm="psi", threshold=0.2):
-        self.reference = reference_df
-        self.algorithm = algorithm
-        self.threshold = threshold
-        self._func = get_drift_function(algorithm)
+    def __init__(self, reference_df: pd.DataFrame):
+        """
+        Initializes the DriftCheck with the reference dataset.
+        """
+        self.reference_df = reference_df
 
-    # etsi/watchdog/drift_check.py
+    def run(self, current_df: pd.DataFrame, features: List[str], algorithms: List[AlgorithmConfig]) -> Dict:
+        """
+        Runs drift detection on a list of features using a list of algorithm configurations.
 
-    def run(self, current_df, features):
-        results = {}
+        Args:
+            current_df (pd.DataFrame): The dataset to compare against the reference data.
+            features (List[str]): A list of feature names to check for drift.
+            algorithms (List[AlgorithmConfig]): A list of algorithm configurations from the config schema.
+
+        Returns:
+            Dict: A nested dictionary with drift results. 
+                  Example: {'age': {'psi': <DriftResult>}, 'salary': {'psi': <DriftResult>}}
+        """
+        all_results = {}
+
         for feat in features:
-            if feat not in self.reference.columns or feat not in current_df.columns:
+            if feat not in self.reference_df.columns or feat not in current_df.columns:
                 print(f"[etsi-watchdog] Skipping '{feat}' — missing in one of the datasets.")
                 continue
 
-            result = self._func(
-                reference_df=self.reference,
-                current_df=current_df,
-                feature=feat,
-                threshold=self.threshold
-            )
+            all_results[feat] = {}
+            for algo_config in algorithms:
+                try:
+                    drift_function = get_drift_function(algo_config.name)
+                    result = drift_function(
+                        reference_df=self.reference_df,
+                        current_df=current_df,
+                        feature=feat,
+                        threshold=algo_config.threshold
+                    )
+                    if result is not None:
+                        all_results[feat][algo_config.name] = result
 
-            if result is not None:
-                results[feat] = result
-        return results
-
+                except Exception as e:
+                    print(f"[etsi-watchdog] Error running algorithm '{algo_config.name}' on feature '{feat}': {e}")
+        
+        return all_results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,21 @@
 [project]
 name = "etsi-watchdog"
-version = "0.2.2"
+version = "0.2.2" 
 description = "Real-time data drift detection for machine learning pipelines."
 authors = [{name = "Etsi", email = "etsi.hq@gmail.com"}]
 license = {text = "BSD-2-Clause"}
-dependencies = ["pandas", "numpy", "slack_sdk"]
+dependencies = [
+    "pandas",
+    "numpy", "slack_sdk",
+    "PyYAML",   # Added for parsing config.yaml files
+    "click",    # Added for the command-line interface (CLI)
+    "scipy"     # Added for statistical tests like KS-test
+]
 readme = "PYPIREADME.md"
 requires-python = ">=3.8"
+# This section creates the command-line tool
+[project.scripts]
+etsi-watchdog = "etsi.watchdog.cli:cli"
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]


### PR DESCRIPTION
# feat(cli): Add command-line interface

## Body

> **Note:** This PR depends on #19  (the YAML backend) and should be reviewed and merged after the YAML backend.

This PR adds a user-friendly, click-based command-line interface (CLI) on top of the YAML configuration system. It provides two commands, `from-config` and `detect`, making the tool accessible and easy to integrate into automated pipelines.

This is **Part 2 of 2**.

### Key Changes

- **New cli.py Module:** Adds a new CLI with two sub-commands (`from-config`, `detect`) for running drift checks directly from the terminal.
- **Script Entry Point:** The `pyproject.toml` file has been updated to register the `etsi-watchdog` command, making it available system-wide upon installation.
- **Added click dependency.**

### How to Test

- Checkout this branch, which includes the backend from Part 1.
- Install the package in editable mode:
  
  ```bash
  pip install -e .
  ```

- Run either of the new commands:

#### A) Using the YAML file:

```bash
etsi-watchdog from-config --config config.yaml
```

#### B) Using direct arguments:

```bash
etsi-watchdog detect --ref data/reference.csv --current data/live.csv --features "age,salary"
```

### Example Output

```text
$ etsi-watchdog from-config --config config.yaml

Loading configuration from: config.yaml
Loading data...
Loaded reference data: 5 rows
Loaded current data: 5 rows
Running drift check on features: ['age', 'salary']
... UserWarning: [etsi-watchdog] Sample size too small for reliable PSI (<50): 5
Results saved to: config_drift_report.json
Drift check complete.
✅ Done.
```

Closes #26 